### PR TITLE
Made Mongo collection name configurable.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             label 'docker'
-            image 'gradle:4.8.0-jdk8-alpine'
+            image 'gradle:4.10.3-jdk8-alpine'
         }
     }
     stages {

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ compile('no.fint:fint-audit-mongo-plugin:1.4.0')
 | fint.audit.mongo.databasename | fint-audit | |
 | fint.audit.mongo.hostname | localhost | if connection-string is set this will be ignored |
 | fint.audit.mongo.port | 27017 | if connection-string is set this will be ignored |
-| fint.audit.mongo.core-pool-size | 2 | |
-| fint.audit.mongo.max-pool-size | 4 | |
-| fint.audit.mongo.queue-capacity | 1000000 | |
+| fint.audit.mongo.buffer-size | 100000 | Number of audit events that can be pending delivery. |
+| fint.audit.mongo.rate | 5000 | Scheduling rate for worker thread writing events to MongoDB. |
 | fint.audit.test-mode | false | |
 
 The `fint.audit.test-mode` will setup an embedded mongodb using [Fongo](https://github.com/fakemongo/fongo).

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ compile('no.fint:fint-audit-mongo-plugin:1.4.0')
 | Key | Default value | Comment |
 |-----|---------------|---------|
 | fint.audit.mongo.connection-string | localhost | Example: `mongodb://app_user:bestPo55word3v3r@localhost/%s`|
-| fint.audit.mongo.databasename | fint-audit | |
 | fint.audit.mongo.hostname | localhost | if connection-string is set this will be ignored |
 | fint.audit.mongo.port | 27017 | if connection-string is set this will be ignored |
+| fint.audit.mongo.databasename | fint-audit | Name of database. |
+| fint.audit.mongo.collection | auditEvent | Name of collection.  Can either be a fixed string or a field from the event in the form `$fieldName`. |
 | fint.audit.mongo.buffer-size | 100000 | Number of audit events that can be pending delivery. |
 | fint.audit.mongo.rate | 5000 | Scheduling rate for worker thread writing events to MongoDB. |
 | fint.audit.test-mode | false | |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/no/fint/audit/FintAuditConfig.java
+++ b/src/main/java/no/fint/audit/FintAuditConfig.java
@@ -4,9 +4,8 @@ import com.github.fakemongo.Fongo;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
-import no.fint.audit.plugin.mongo.AuditMongo;
-import no.fint.audit.plugin.mongo.AuditMongoRepository;
-import no.fint.audit.plugin.mongo.AuditMongoWorker;
+import no.fint.audit.plugin.mongo.*;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +14,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.util.StringUtils;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -28,6 +28,8 @@ public class FintAuditConfig extends AbstractMongoConfiguration {
     @Value("${fint.audit.mongo.databasename:fint-audit}")
     private String databaseName;
 
+    @Value("${fint.audit.mongo.collection:auditEvent}")
+    private String collectionName;
 
     @Value("${fint.audit.mongo.hostname:localhost}")
     private String hostname;
@@ -82,4 +84,20 @@ public class FintAuditConfig extends AbstractMongoConfiguration {
         return new AuditMongoRepository();
     }
 
+    @Bean
+    public CollectionNameSupplier collectionNameSupplier() {
+        if (collectionName.startsWith("$")) {
+            Method readMethod = BeanUtils
+                    .getPropertyDescriptor(MongoAuditEvent.class, collectionName.substring(1))
+                    .getReadMethod();
+            return mongoAuditEvent -> {
+                try {
+                    return (String) readMethod.invoke(mongoAuditEvent);
+                } catch (Exception e) {
+                    return "auditEvent";
+                }
+            };
+        }
+        return (mongoAuditEvent -> collectionName);
+    }
 }

--- a/src/main/java/no/fint/audit/FintAuditConfig.java
+++ b/src/main/java/no/fint/audit/FintAuditConfig.java
@@ -4,6 +4,7 @@ import com.github.fakemongo.Fongo;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
+import lombok.extern.slf4j.Slf4j;
 import no.fint.audit.plugin.mongo.*;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@Slf4j
 @Configuration
 @EnableScheduling
 @EnableMongoRepositories(basePackageClasses = AuditMongoRepository.class)
@@ -90,6 +92,7 @@ public class FintAuditConfig extends AbstractMongoConfiguration {
             Method readMethod = BeanUtils
                     .getPropertyDescriptor(MongoAuditEvent.class, collectionName.substring(1))
                     .getReadMethod();
+            log.debug("Using method {} for collection name", readMethod);
             return mongoAuditEvent -> {
                 try {
                     return (String) readMethod.invoke(mongoAuditEvent);

--- a/src/main/java/no/fint/audit/FintAuditConfig.java
+++ b/src/main/java/no/fint/audit/FintAuditConfig.java
@@ -16,9 +16,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
 
 @Slf4j
 @Configuration
@@ -66,9 +65,7 @@ public class FintAuditConfig extends AbstractMongoConfiguration {
 
     @Override
     protected Collection<String> getMappingBasePackages() {
-        List<String> packages = new ArrayList<>();
-        packages.add(AuditMongoRepository.class.getPackage().getName());
-        return packages;
+        return Collections.singleton(AuditMongoRepository.class.getPackage().getName());
     }
 
     @Bean

--- a/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
+++ b/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
@@ -18,8 +18,8 @@ public class AuditMongoRepository {
 
     public void save(MongoAuditEvent mongoAuditEvent) {
         String collectionName = collectionNameSupplier.apply(mongoAuditEvent);
-        log.debug("Try save to {} - {}", collectionName, mongoAuditEvent);
-        mongoTemplate.save(mongoAuditEvent, collectionName);
+        log.debug("Try insert to {} - {}", collectionName, mongoAuditEvent);
+        mongoTemplate.insert(mongoAuditEvent, collectionName);
     }
 
     @Profile(value = "test")

--- a/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
+++ b/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
@@ -16,7 +16,7 @@ public class AuditMongoRepository {
     @Autowired
     private CollectionNameSupplier collectionNameSupplier;
 
-    public void save(MongoAuditEvent mongoAuditEvent) {
+    public void insert(MongoAuditEvent mongoAuditEvent) {
         String collectionName = collectionNameSupplier.apply(mongoAuditEvent);
         log.debug("Try insert to {} - {}", collectionName, mongoAuditEvent);
         mongoTemplate.insert(mongoAuditEvent, collectionName);

--- a/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
+++ b/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
@@ -1,12 +1,13 @@
 package no.fint.audit.plugin.mongo;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
-
+@Slf4j
 public class AuditMongoRepository {
 
     @Autowired
@@ -15,8 +16,10 @@ public class AuditMongoRepository {
     @Autowired
     private CollectionNameSupplier collectionNameSupplier;
 
-    public void insert(MongoAuditEvent mongoAuditEvent) {
-        mongoTemplate.insert(mongoAuditEvent, collectionNameSupplier.apply(mongoAuditEvent));
+    public void save(MongoAuditEvent mongoAuditEvent) {
+        String collectionName = collectionNameSupplier.apply(mongoAuditEvent);
+        log.debug("Try save to {} - {}", collectionName, mongoAuditEvent);
+        mongoTemplate.save(mongoAuditEvent, collectionName);
     }
 
     @Profile(value = "test")

--- a/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
+++ b/src/main/java/no/fint/audit/plugin/mongo/AuditMongoRepository.java
@@ -12,8 +12,11 @@ public class AuditMongoRepository {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private CollectionNameSupplier collectionNameSupplier;
+
     public void insert(MongoAuditEvent mongoAuditEvent) {
-        mongoTemplate.insert(mongoAuditEvent);
+        mongoTemplate.insert(mongoAuditEvent, collectionNameSupplier.apply(mongoAuditEvent));
     }
 
     @Profile(value = "test")

--- a/src/main/java/no/fint/audit/plugin/mongo/CollectionNameSupplier.java
+++ b/src/main/java/no/fint/audit/plugin/mongo/CollectionNameSupplier.java
@@ -1,0 +1,7 @@
+package no.fint.audit.plugin.mongo;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface CollectionNameSupplier extends Function<MongoAuditEvent, String> {
+}


### PR DESCRIPTION
Made the collection used to store events configurable.  It could either be a constant string, or a field name from the audit event using the format `$fieldName`.

In addition, use `MongoOperations.insert()` instead of `.save()` to support partitioned collections.  The `.save()` operation is an "upsert", meaning MongoDB will try to query the collection for an existing item before inserting it as a new.